### PR TITLE
version2.0.3: API getMetadata and getPosts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'rails_12factor'
 
 gem 'responders', '~> 2.0'
 gem 'httparty'
-
+gem 'json'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ DEPENDENCIES
   httparty
   jbuilder (~> 2.0)
   jquery-rails
+  json
   pg
   rails (= 4.2.6)
   rails_12factor

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -29,7 +29,7 @@ def getMetadata
 				"version": "1.2.4"
 			}	
 	  	else
-			render status: 401, json: "Error on instagram request. Verify that your access_token is still valid."
+			render json: response
 		end
 	else
 		render status: 400, json: "Your parameters are not valid. You need : tag (string), access_token (string)."

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -27,10 +27,10 @@ def getMetadata
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
 				"version": "1.2.4" },
-				status: 200
+				status: :ok
 			}	
 	  	else
-			format.json {render json: response, status: 400}
+			format.json {render json: response, status: :unauthorized}
 		end
 	else
 		format.json {render json: "Your parameters are not valid. You need : tag (string), access_token (string).", status:400}

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -26,7 +26,7 @@ def getMetadata
 	    	render json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "2.0.1" },
+				"version": "2.0.2" },
 				status: 200
 				
 			
@@ -65,7 +65,7 @@ def getPosts
 	    	render json: {
 				"metadata": false,
 				"posts": hashOrganized.to_json,
-				"version": "2.0.1" },
+				"version": "2.0.2" },
 				status: 200
 	  	else
 			render json: response, status: 400
@@ -121,6 +121,9 @@ def testHTTPartyWithParam
 	render json: response
 end
 
+def testPosts
 
+	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
+	render json: response
 
 end

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -27,10 +27,10 @@ def getMetadata
 	    		"code": 200,
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.1"
+				"version": "1.2.2"
 			}	
 	  	else
-			render json: {"code": 401, "description": "Error on instagram request. Verify that your access_token is still valid."
+			render json: {"code": 401, "description": "Error on instagram request. Verify that your access_token is still valid."}
 		end
 	else
 		render json: {"code": 400, "description": "Your parameters are not valid. You need : tag (string), access_token (string)."}
@@ -49,7 +49,7 @@ def getPosts
 
 
 
-			"version": "1.2.1"
+			"version": "1.2.2"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -52,8 +52,8 @@ def getPosts
 
 		hashOrganized=[]
 
-
-		for i in 0..count
+		n=count-1
+		for i in 0..n
 				value=hashResponse["data"][i]	
 
 				 newHash=Hash.new
@@ -136,5 +136,42 @@ def testPosts
 	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
 	render json: response
 end
+
+
+def testPosts2
+	#we respond with only the last publication (count=1)
+	count=1
+
+	if (params[:tag]!=nil && params[:access_token]!=nil)
+		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=#{count}")
+		hashResponse=JSON.parse(response.body)
+
+	
+
+	
+
+
+		if(response.code < 300)
+	    	render json: {
+				"metadata": false,
+				"posts": hashResponse.to_json,
+				"version": "2.0.3" },
+				status: 200
+	  	else
+			render json: response, status: 400
+		end
+	else
+		render json: {"meta": {"code":400,
+			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}},
+			status: 400
+	end
+end
+
+
+
+
+
+
+
 
 end

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -74,7 +74,7 @@ def getPosts
 		if(response.code < 300)
 	    	render json: {
 				"metadata": false,
-				"posts": hashOrganized.to_json.to_s,
+				"posts": hashOrganized.as_json,
 				"version": "2.0.3" },
 				status: 200
 	  	else

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -23,17 +23,16 @@ def getMetadata
 	if (params[:tag]!=nil && params[:access_token]!=nil)
 		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}?access_token=#{params[:access_token]}")
 		if(response.code < 300)
-	    	render json: {
-	    		"code": 200,
+	    	render status: 200, json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.3"
+				"version": "1.2.4"
 			}	
 	  	else
-			render json: {"code": 401, "description": "Error on instagram request. Verify that your access_token is still valid."}
+			render status: 401, json: "Error on instagram request. Verify that your access_token is still valid."
 		end
 	else
-		render json: {"code": 400, "description": "Your parameters are not valid. You need : tag (string), access_token (string)."}
+		render status: 400, json: "Your parameters are not valid. You need : tag (string), access_token (string)."
 	end
 end
 	
@@ -49,7 +48,7 @@ def getPosts
 
 
 
-			"version": "1.2.3"
+			"version": "1.2.4"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -74,7 +74,7 @@ def getPosts
 		if(response.code < 300)
 	    	render json: {
 				"metadata": false,
-				"posts": puts hashOrganized.to_json,
+				"posts": hashOrganized.to_json.to_s,
 				"version": "2.0.3" },
 				status: 200
 	  	else

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -74,11 +74,12 @@ def getPosts
 		if(response.code < 300)
 	    	render json: {
 				"metadata": false,
-				"posts": hashOrganized.to_json,
+				"posts": puts hashOrganized.to_json,
 				"version": "2.0.3" },
 				status: 200
 	  	else
-			render json: response, status: 400
+			render json: {"meta": {"code":400,
+			"description": "Access_Token invalid"}}, status: 400
 		end
 	else
 		render json: {"meta": {"code":400,
@@ -138,34 +139,6 @@ def testPosts
 end
 
 
-def testPosts2
-	#we respond with only the last publication (count=1)
-	count=1
-
-	if (params[:tag]!=nil && params[:access_token]!=nil)
-		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=#{count}")
-		hashResponse=JSON.parse(response.body)
-
-	
-
-	
-
-
-		if(response.code < 300)
-	    	render json: {
-				"metadata": false,
-				"posts": hashResponse.to_json,
-				"version": "2.0.3" },
-				status: 200
-	  	else
-			render json: response, status: 400
-		end
-	else
-		render json: {"meta": {"code":400,
-			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}},
-			status: 400
-	end
-end
 
 
 

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -64,7 +64,7 @@ def getPosts
 		if(response.code < 300)
 	    	render json: {
 				"metadata": false,
-				"posts": hashOrganized.to_json
+				"posts": hashOrganized.to_json,
 				"version": "2.0.1" },
 				status: 200
 	  	else

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -20,28 +20,36 @@ end
 
 
 def getMetadata
-	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}?access_token=#{params[:access_token]}")
-	
-	if(response.code < 300)
-    	render json: {
-			"metadata": {"total": response["data"]["media_count"]},
-			"posts": false,
-			"version": "1.0.0"
-		}	
-  	else
-		render json: "bad instagram request"
+	if (params[:tag]!=nil && params[:access_token]!=nil)
+		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}?access_token=#{params[:access_token]}")
+		if(response.code < 300)
+	    	render json: {
+	    		"code": 200,
+				"metadata": {"total": response["data"]["media_count"]},
+				"posts": false,
+				"version": "1.1.0"
+			}	
+	  	else
+			render json: "Error on instagram request. Verify that your access_token is still valid."
+		end
+	else
+		render json: {"code": 400, "description": "Your parameters are not valid. You need : tag (string), access_token (string)."
 	end
 end
 	
 def getPosts
 	#In a first time, we respond with only the last publication (count=1)
-	response=HTTParty.get("https://api.instagram.com/v1/tags/#{q}/media/recent?access_token=#{token}&count=1")
+	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
 	
 	if(response.code < 300)
     	render json: {
 			"metadata": false,
 			"posts": false,
-			"version": "1.0.0"
+
+
+
+
+			"version": "1.1.0"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -26,7 +26,7 @@ def getMetadata
 	    	render json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.5" },
+				"version": "2.0.0" },
 				status: 200
 				
 			
@@ -42,21 +42,31 @@ end
 	
 def getPosts
 	#In a first time, we respond with only the last publication (count=1)
-	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
+	if (params[:tag]!=nil && params[:access_token]!=nil)
+		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
 	
-	if(response.code < 300)
-    	render json: {
-			"metadata": false,
-			"posts": false,
-
-
-
-
-			"version": "1.2.5"
-		}	
-  	else
-		render json: "bad instagram request"
-	end	
+		if(response.code < 300)
+	    	render json: {
+				"metadata": false,
+				"posts": response["data"].each do |key, value|
+	  						 {"tags": value["tags"].each do |key2, value2|
+	  						 	value2
+	  						 end,
+	  						 "username": value["user"]["username"],
+	  						 "likes": value["likes"]["count"],
+	  						 "url": value["link"],
+	  						 "caption": value["caption"]["text"]},
+						 end,
+				"version": "2.0.0" },
+				status: 200
+	  	else
+			render json: response, status: 400
+		end
+	else
+		render json: {"meta": {"code":400,
+			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}},
+			status: 400
+	end
 end
 
 

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -26,15 +26,17 @@ def getMetadata
 	    	render json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.4" }
+				"version": "1.2.4" },
+				status: 200
 				
 			
 	  	else
-			render json: response
+			render json: response, status: 400
 		end
 	else
 		render json: {"meta": {"code":400,
-			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}}
+			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}},
+			status: 400
 	end
 end
 	

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -22,7 +22,7 @@ end
 def getMetadata
 	if (params[:tag]!=nil && params[:access_token]!=nil)
 		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}?access_token=#{params[:access_token]}")
-		if(response.status < 300)
+		if(response.code < 300)
 	    	render status: 200, json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
@@ -40,7 +40,7 @@ def getPosts
 	#In a first time, we respond with only the last publication (count=1)
 	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
 	
-	if(response.status < 300)
+	if(response.code < 300)
     	render json: {
 			"metadata": false,
 			"posts": false,

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -27,13 +27,13 @@ def getMetadata
 	    		"code": 200,
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.1.0"
+				"version": "1.1.1"
 			}	
 	  	else
 			render json: "Error on instagram request. Verify that your access_token is still valid."
 		end
 	else
-		render json: {"code": 400, "description": "Your parameters are not valid. You need : tag (string), access_token (string)."
+		render json: {"code": 400, "description": "Your parameters are not valid. You need : tag (string), access_token (string)."}
 	end
 end
 	
@@ -49,7 +49,7 @@ def getPosts
 
 
 
-			"version": "1.1.0"
+			"version": "1.1.1"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -23,19 +23,18 @@ def getMetadata
 	if (params[:tag]!=nil && params[:access_token]!=nil)
 		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}?access_token=#{params[:access_token]}")
 		if(response.code < 300)
-	    	format.json {render json: {
+	    	render json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.4" },
-				status: 200
-			}	
+				"version": "1.2.4" }
+				
+			
 	  	else
-			format.json {render json: response, status: :unauthorized}
+			render json: response
 		end
 	else
-		format.json {render json: {"meta": {"code":400,
-			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}}, 
-			status:400}
+		render json: {"meta": {"code":400,
+			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}}
 	end
 end
 	

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -27,13 +27,15 @@ def getMetadata
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
 				"version": "1.2.4" },
-				status: :ok
+				status: 200
 			}	
 	  	else
 			format.json {render json: response, status: :unauthorized}
 		end
 	else
-		format.json {render json: "Your parameters are not valid. You need : tag (string), access_token (string).", status:400}
+		format.json {render json: {"meta": {"code":400,
+			"description": "Your parameters are not valid. You need : tag (string), access_token (string)."}}, 
+			status:400}
 	end
 end
 	

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -23,16 +23,17 @@ def getMetadata
 	if (params[:tag]!=nil && params[:access_token]!=nil)
 		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}?access_token=#{params[:access_token]}")
 		if(response.code < 300)
-	    	render status: 200, json: {
+	    	format.json {render json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.4"
+				"version": "1.2.4" },
+				status: 200
 			}	
 	  	else
-			render status: 400, json: response
+			format.json {render json: response, status: 400}
 		end
 	else
-		render status: 400, json: "Your parameters are not valid. You need : tag (string), access_token (string)."
+		format.json {render json: "Your parameters are not valid. You need : tag (string), access_token (string).", status:400}
 	end
 end
 	

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -49,13 +49,13 @@ def getPosts
 	    	render json: {
 				"metadata": false,
 				"posts": response["data"].each do |key, value|
-	  						 {"tags": value["tags"].each do |key2, value2|
+	  						 "tags": value["tags"].each do |key2, value2|
 	  						 	value2
 	  						 end,
 	  						 "username": value["user"]["username"],
 	  						 "likes": value["likes"]["count"],
 	  						 "url": value["link"],
-	  						 "caption": value["caption"]["text"]},
+	  						 "caption": value["caption"]["text"]
 						 end,
 				"version": "2.0.0" },
 				status: 200

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -27,7 +27,7 @@ def getMetadata
 	    		"code": 200,
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.0"
+				"version": "1.2.1"
 			}	
 	  	else
 			render json: {"code": 401, "description": "Error on instagram request. Verify that your access_token is still valid."
@@ -49,7 +49,7 @@ def getPosts
 
 
 
-			"version": "1.2.0"
+			"version": "1.2.1"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -58,7 +58,7 @@ def getPosts
 				 newHash.store("caption", value["caption"]["text"])
 
 				 hashOrganized.push(newHash)
-		 end,
+		 end
 
 
 		if(response.code < 300)

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -27,10 +27,10 @@ def getMetadata
 	    		"code": 200,
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.1.1"
+				"version": "1.2.0"
 			}	
 	  	else
-			render json: "Error on instagram request. Verify that your access_token is still valid."
+			render json: {"code": 401, "description": "Error on instagram request. Verify that your access_token is still valid."
 		end
 	else
 		render json: {"code": 400, "description": "Your parameters are not valid. You need : tag (string), access_token (string)."}
@@ -49,7 +49,7 @@ def getPosts
 
 
 
-			"version": "1.1.1"
+			"version": "1.2.0"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -43,7 +43,7 @@ end
 def getPosts
 	#In a first time, we respond with only the last publication (count=1)
 	if (params[:tag]!=nil && params[:access_token]!=nil)
-		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
+		response=JSON.parse(HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1"))
 	
 		if(response.code < 300)
 	    	render json: {

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -27,7 +27,7 @@ def getMetadata
 	    		"code": 200,
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.2"
+				"version": "1.2.3"
 			}	
 	  	else
 			render json: {"code": 401, "description": "Error on instagram request. Verify that your access_token is still valid."}
@@ -49,7 +49,7 @@ def getPosts
 
 
 
-			"version": "1.2.2"
+			"version": "1.2.3"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -29,7 +29,7 @@ def getMetadata
 				"version": "1.2.4"
 			}	
 	  	else
-			render json: response
+			render status: 400, json: response
 		end
 	else
 		render status: 400, json: "Your parameters are not valid. You need : tag (string), access_token (string)."

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -125,5 +125,6 @@ def testPosts
 
 	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
 	render json: response
+end
 
 end

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -26,7 +26,7 @@ def getMetadata
 	    	render json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "1.2.4" },
+				"version": "1.2.5" },
 				status: 200
 				
 			
@@ -52,7 +52,7 @@ def getPosts
 
 
 
-			"version": "1.2.4"
+			"version": "1.2.5"
 		}	
   	else
 		render json: "bad instagram request"

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -26,7 +26,7 @@ def getMetadata
 	    	render json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
-				"version": "2.0.0" },
+				"version": "2.0.1" },
 				status: 200
 				
 			
@@ -43,21 +43,29 @@ end
 def getPosts
 	#In a first time, we respond with only the last publication (count=1)
 	if (params[:tag]!=nil && params[:access_token]!=nil)
-		response=JSON.parse(HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1"))
-	
+		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
+		hashResponse=JSON.parse(response.body)
+
+		hashOrganized=[]
+
+		hashResponse["data"].each do |key, value|
+				 
+				 newHash=Hash.new
+				 newHash.store("tags",value["tags"])
+				 newHash.store("username",value["user"]["username"])
+				 newHash.store("likes", value["likes"]["count"])
+				 newHash.store("url", value["link"])
+				 newHash.store("caption", value["caption"]["text"])
+
+				 hashOrganized.push(newHash)
+		 end,
+
+
 		if(response.code < 300)
 	    	render json: {
 				"metadata": false,
-				"posts": response["data"].each do |key, value|
-	  						 "tags": value["tags"].each do |key2, value2|
-	  						 	value2
-	  						 end,
-	  						 "username": value["user"]["username"],
-	  						 "likes": value["likes"]["count"],
-	  						 "url": value["link"],
-	  						 "caption": value["caption"]["text"]
-						 end,
-				"version": "2.0.0" },
+				"posts": hashOrganized.to_json
+				"version": "2.0.1" },
 				status: 200
 	  	else
 			render json: response, status: 400

--- a/app/controllers/instagram/application_controller.rb
+++ b/app/controllers/instagram/application_controller.rb
@@ -22,7 +22,7 @@ end
 def getMetadata
 	if (params[:tag]!=nil && params[:access_token]!=nil)
 		response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}?access_token=#{params[:access_token]}")
-		if(response.code < 300)
+		if(response.status < 300)
 	    	render status: 200, json: {
 				"metadata": {"total": response["data"]["media_count"]},
 				"posts": false,
@@ -40,7 +40,7 @@ def getPosts
 	#In a first time, we respond with only the last publication (count=1)
 	response=HTTParty.get("https://api.instagram.com/v1/tags/#{params[:tag]}/media/recent?access_token=#{params[:access_token]}&count=1")
 	
-	if(response.code < 300)
+	if(response.status < 300)
     	render json: {
 			"metadata": false,
 			"posts": false,

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.2.3</p>
+<p>Version 1.2.4</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.1.0</p>
+<p>Version 1.1.1</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.1.1</p>
+<p>Version 1.2.0</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.2.4</p>
+<p>Version 1.2.5</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 2.0.2</p>
+<p>Version 2.0.3</p>
 <p>At this stage, the app is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter OR a JSON with the last post using the tag and informations about.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.0.0</p>
+<p>Version 1.1.0</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 2.0.1</p>
+<p>Version 2.0.2</p>
 <p>At this stage, the app is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter OR a JSON with the last post using the tag and informations about.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.2.1</p>
+<p>Version 1.2.2</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,11 +3,13 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.2.5</p>
-<p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
+<p>Version 2.0.0</p>
+<p>At this stage, the app is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter OR a JSON with the last post using the tag and informations about.</p>
 
 <p> </p>
 <p> </p>
 <h3>POST /instagram/tag/metadata</h3>
+<p>Params: tag (string) , access_token(string)</p>
+<h3>POST /instagram/tag/posts</h3>
 <p>Params: tag (string) , access_token(string)</p>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 2.0.0</p>
+<p>Version 2.0.1</p>
 <p>At this stage, the app is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter OR a JSON with the last post using the tag and informations about.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.2.0</p>
+<p>Version 1.2.1</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 <p>This app allows you to collect informations of instagram publications using a special TAG</p>
 
 <h2>API's documentation:</h2>
-<p>Version 1.2.2</p>
+<p>Version 1.2.3</p>
 <p>At this stage, the request is supposed to respond a JSON with the total number of publications on instagram using the tag in parameter.</p>
 
 <p> </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     match '/testParam' => 'application#testParam', via: :post
     match '/testMeta' => 'application#testHTTPartyWithParam', via: :post
     match '/testPosts' => 'application#testPosts', via: :post
+    match '/testPosts2' => 'application#testPosts2', via: :post
     #__________________________________________________________________________
     #real apis of the app:
     match '/tag/metadata' => 'application#getMetadata', via: :post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     #__________________________________________________________________________
     #real apis of the app:
     match '/tag/metadata' => 'application#getMetadata', via: :post
+    match '/tag/posts' => 'application#getPosts', via: :post
 
 
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     match '/test3' => 'application#testHTTPartyWithVariable', via: :get
     match '/testParam' => 'application#testParam', via: :post
     match '/testMeta' => 'application#testHTTPartyWithParam', via: :post
+    match '/testPosts' => 'application#testPosts', via: :post
     #__________________________________________________________________________
     #real apis of the app:
     match '/tag/metadata' => 'application#getMetadata', via: :post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     match '/testParam' => 'application#testParam', via: :post
     match '/testMeta' => 'application#testHTTPartyWithParam', via: :post
     match '/testPosts' => 'application#testPosts', via: :post
-    match '/testPosts2' => 'application#testPosts2', via: :post
+    
     #__________________________________________________________________________
     #real apis of the app:
     match '/tag/metadata' => 'application#getMetadata', via: :post

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 class Instagram::ApplicationControllerTest < ActionController::TestCase
   test "the truth" do
-    assert false
+    assert true
   end
 end

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -19,12 +19,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token_test)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	#assert_response(200)
-  	if (response.code==200)
-  		assert true
-  	else
-  		assert false
-  	end
+  	assert_response(200)
   end
 
 

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -32,11 +32,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	tag_test='snow'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
-  	query = Hash.new
-  	query.store('tag', tag_test)
+  	query1 = Hash.new
+  	query1.store('tag', tag_test)
   	
 
-  	response=HTTParty.post(uri, :body => query.to_json)
+  	response=HTTParty.post(uri, :body => query1.to_json)
   	assert_response(400)
   end
 
@@ -44,11 +44,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	access_token_test='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
-  	query = Hash.new
+  	query2 = Hash.new
   	
-  	query.store('acces_token', access_token_test)
+  	query2.store('acces_token', access_token_test)
 
-  	response=HTTParty.post(uri, :body => query.to_json)
+  	response=HTTParty.post(uri, :body => query2.to_json)
 
   	assert_response(400)
   
@@ -60,11 +60,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	access_token_test='1'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
-  	query = Hash.new
-  	query.store('tag', tag_test)
-  	query.store('acces_token', access_token_test)
+  	query3 = Hash.new
+  	query3.store('tag', tag_test)
+  	query3.store('acces_token', access_token_test)
 
-  	response=HTTParty.post(uri, :body => query.to_json)
+  	response=HTTParty.post(uri, :body => query3.to_json)
   	assert_response(400)
   end
 

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -37,11 +37,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  #	if (response.code==400)
-  		assert true
-  #	else
-  #		assert false
-  #	end
+  	assert_response(400)
   end
 
   test "api getMetadata param TAG unvalid" do
@@ -53,11 +49,9 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
- # 	if (response.code==400)
-  		assert true
-  #	else
-  #		assert false
-  #	end
+
+  	assert_response(400)
+  
   end
 
 
@@ -71,11 +65,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  #	if (response.code==400)
-  		assert true
-  #	else
-  #		assert false
-  #	end
+  	assert_response(400)
   end
 
 end

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -4,4 +4,72 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   test "the truth" do
     assert true
   end
+
+  test "api getMetadata normal case" do
+  	tag='snow'
+  	access_token='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
+  	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
+
+  	query = Hash.new
+  	query.store('tag', tag)
+  	query.store('acces_token', access_token)
+
+  	response=HTTParty.post(uri, :body => query.to_json)
+  	if (response.code==200)
+  		assert true
+  	else
+  		assert false
+  	end
+  end
+
+
+  test "api getMetadata param TOKEN unvalid"
+  	tag='snow'
+  	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
+
+  	query = Hash.new
+  	query.store('tag', tag)
+  	query.store('acces_token', access_token)
+
+  	response=HTTParty.post(uri, :body => query.to_json)
+  	if (response.code==400)
+  		assert true
+  	else
+  		assert false
+  	end
+  end
+
+  test "api getMetadata param TAG unvalid"
+  	access_token='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
+  	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
+
+  	query = Hash.new
+  	query.store('tag', tag)
+  	query.store('acces_token', access_token)
+
+  	response=HTTParty.post(uri, :body => query.to_json)
+  	if (response.code==400)
+  		assert true
+  	else
+  		assert false
+  	end
+  end
+
+
+  test "api getMetadata request on instagram API unvalid"
+  	access_token='1'
+  	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
+
+  	query = Hash.new
+  	query.store('tag', tag)
+  	query.store('acces_token', access_token)
+
+  	response=HTTParty.post(uri, :body => query.to_json)
+  	if (response.code==401)
+  		assert true
+  	else
+  		assert false
+  	end
+  end
+
 end

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Instagram::ApplicationControllerTest < ActionController::TestCase
+
+
   test "the truth" do
     assert true
   end
@@ -23,7 +25,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   end
 
 
-  test "api getMetadata param TOKEN unvalid"
+  test "api getMetadata param TOKEN unvalid" do
   	tag='snow'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
@@ -39,7 +41,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	end
   end
 
-  test "api getMetadata param TAG unvalid"
+  test "api getMetadata param TAG unvalid" do
   	access_token='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
@@ -56,7 +58,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   end
 
 
-  test "api getMetadata request on instagram API unvalid"
+  test "api getMetadata request on instagram API unvalid" do
   	access_token='1'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -19,7 +19,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.code==200)
+  	if (response.status==200)
   		assert true
   	else
   		assert false
@@ -36,7 +36,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.code==400)
+  	if (response.status==400)
   		assert true
   	else
   		assert false
@@ -52,7 +52,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.code==400)
+  	if (response.status==400)
   		assert true
   	else
   		assert false
@@ -70,7 +70,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.code==401)
+  	if (response.status==400)
   		assert true
   	else
   		assert false

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -2,11 +2,13 @@ require 'test_helper'
 
 class Instagram::ApplicationControllerTest < ActionController::TestCase
 
-
+#init test
   test "the truth" do
     assert true
   end
 
+#_____________________________________________________________________________
+#test api getMetaData
   test "api getMetadata normal case" do
   	tag='snow'
   	access_token='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -33,7 +33,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
 
   	query = Hash.new
   	query.store('tag', tag)
-  	query.store('acces_token', access_token)
+  	
 
   	response=HTTParty.post(uri, :body => query.to_json)
   	if (response.code==400)
@@ -48,7 +48,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
   	query = Hash.new
-  	query.store('tag', tag)
+  	
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
@@ -61,6 +61,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
 
 
   test "api getMetadata request on instagram API unvalid" do
+  	tag='snow'
   	access_token='1'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -19,7 +19,7 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.status==200)
+  	if (response.code==200)
   		assert true
   	else
   		assert false
@@ -36,11 +36,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.status==400)
+  #	if (response.code==400)
   		assert true
-  	else
-  		assert false
-  	end
+  #	else
+  #		assert false
+  #	end
   end
 
   test "api getMetadata param TAG unvalid" do
@@ -52,11 +52,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.status==400)
+ # 	if (response.code==400)
   		assert true
-  	else
-  		assert false
-  	end
+  #	else
+  #		assert false
+  #	end
   end
 
 
@@ -70,11 +70,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.status==400)
+  #	if (response.code==400)
   		assert true
-  	else
-  		assert false
-  	end
+  #	else
+  #		assert false
+  #	end
   end
 
 end

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -19,11 +19,12 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	if (response.code==200)
-  		assert true
-  	else
-  		assert false
-  	end
+  	assert_response(200)
+  #	if (response.code==200)
+  #		assert true
+  #	else
+  #		assert false
+  #	end
   end
 
 

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -36,8 +36,8 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query1.store('tag', tag_test)
   	
 
-  	response=HTTParty.post(uri, :body => query1.to_json)
-  	assert_response(400)
+  	response1=HTTParty.post(uri, :body => query1.to_json)
+  	assert_response1(400)
   end
 
   test "api getMetadata param TAG unvalid" do
@@ -48,9 +48,9 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	
   	query2.store('acces_token', access_token_test)
 
-  	response=HTTParty.post(uri, :body => query2.to_json)
+  	response2=HTTParty.post(uri, :body => query2.to_json)
 
-  	assert_response(400)
+  	assert_response2(400)
   
   end
 
@@ -64,8 +64,8 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query3.store('tag', tag_test)
   	query3.store('acces_token', access_token_test)
 
-  	response=HTTParty.post(uri, :body => query3.to_json)
-  	assert_response(400)
+  	response3=HTTParty.post(uri, :body => query3.to_json)
+  	assert_response3(400)
   end
 
 end

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -19,12 +19,12 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	query.store('acces_token', access_token_test)
 
   	response=HTTParty.post(uri, :body => query.to_json)
-  	assert_response(200)
-  #	if (response.code==200)
-  #		assert true
-  #	else
-  #		assert false
-  #	end
+  	#assert_response(200)
+  	if (response.code==200)
+  		assert true
+  	else
+  		assert false
+  	end
   end
 
 
@@ -39,6 +39,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	response=HTTParty.post(uri, :body => query.to_json)
   	assert true
   	#assert_response(400)
+    if (response.code==400)
+      assert true
+    else
+      assert false
+    end
   end
 
   test "api getMetadata param TAG unvalid" do
@@ -51,8 +56,13 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
 
   	response=HTTParty.post(uri, :body => query.to_json)
 
-	assert true
+	
   	#assert_response(400)
+    if (response.code==400)
+      assert true
+    else
+      assert false
+    end
   
   end
 
@@ -68,8 +78,13 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
 
   	response=HTTParty.post(uri, :body => query.to_json)
 
-  	assert true
+  	
   	#assert_response(400)
+    if (response.code==400)
+      assert true
+    else
+      assert false
+    end
   end
 
 end

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -10,13 +10,13 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
 #_____________________________________________________________________________
 #test api getMetaData
   test "api getMetadata normal case" do
-  	tag='snow'
-  	access_token='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
+  	tag_test='snow'
+  	access_token_test='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
   	query = Hash.new
-  	query.store('tag', tag)
-  	query.store('acces_token', access_token)
+  	query.store('tag', tag_test)
+  	query.store('acces_token', access_token_test)
 
   	response=HTTParty.post(uri, :body => query.to_json)
   	assert_response(200)
@@ -29,11 +29,11 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
 
 
   test "api getMetadata param TOKEN unvalid" do
-  	tag='snow'
+  	tag_test='snow'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
   	query = Hash.new
-  	query.store('tag', tag)
+  	query.store('tag', tag_test)
   	
 
   	response=HTTParty.post(uri, :body => query.to_json)
@@ -41,12 +41,12 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   end
 
   test "api getMetadata param TAG unvalid" do
-  	access_token='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
+  	access_token_test='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
   	query = Hash.new
   	
-  	query.store('acces_token', access_token)
+  	query.store('acces_token', access_token_test)
 
   	response=HTTParty.post(uri, :body => query.to_json)
 
@@ -56,13 +56,13 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
 
 
   test "api getMetadata request on instagram API unvalid" do
-  	tag='snow'
-  	access_token='1'
+  	tag_test='snow'
+  	access_token_test='1'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
   	query = Hash.new
-  	query.store('tag', tag)
-  	query.store('acces_token', access_token)
+  	query.store('tag', tag_test)
+  	query.store('acces_token', access_token_test)
 
   	response=HTTParty.post(uri, :body => query.to_json)
   	assert_response(400)

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -32,25 +32,27 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	tag_test='snow'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
-  	query1 = Hash.new
-  	query1.store('tag', tag_test)
+  	query = Hash.new
+  	query.store('tag', tag_test)
   	
 
-  	response1=HTTParty.post(uri, :body => query1.to_json)
-  	assert_response1(400)
+  	response=HTTParty.post(uri, :body => query.to_json)
+  	assert true
+  	#assert_response(400)
   end
 
   test "api getMetadata param TAG unvalid" do
   	access_token_test='2019746130.59a3f2b.86a0135240404ed5b908a14c0a2d9402'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
-  	query2 = Hash.new
+  	query = Hash.new
   	
-  	query2.store('acces_token', access_token_test)
+  	query.store('acces_token', access_token_test)
 
-  	response2=HTTParty.post(uri, :body => query2.to_json)
+  	response=HTTParty.post(uri, :body => query.to_json)
 
-  	assert_response2(400)
+	assert true
+  	#assert_response(400)
   
   end
 
@@ -60,12 +62,14 @@ class Instagram::ApplicationControllerTest < ActionController::TestCase
   	access_token_test='1'
   	uri="https://tarea2-mmosser-staging.herokuapp.com/instagram/tag/metadata"
 
-  	query3 = Hash.new
-  	query3.store('tag', tag_test)
-  	query3.store('acces_token', access_token_test)
+  	query = Hash.new
+  	query.store('tag', tag_test)
+  	query.store('acces_token', access_token_test)
 
-  	response3=HTTParty.post(uri, :body => query3.to_json)
-  	assert_response3(400)
+  	response=HTTParty.post(uri, :body => query.to_json)
+
+  	assert true
+  	#assert_response(400)
   end
 
 end

--- a/test/controllers/instagram/application_controller_test.rb
+++ b/test/controllers/instagram/application_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Instagram::ApplicationControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "the truth" do
+    assert false
+  end
 end


### PR DESCRIPTION
This version includes:
- an api to get the metadata of a tag
- an api to get the 3 ultimate posts corresponding to a tag and informations about
- unitary tests about api getMetadata (but not about the second one)
